### PR TITLE
chore: dead links removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ This is a curated list of tools, resources, and services supporting the Digital 
 - [Data Analysis](#data-analysis)
 - [Data Extraction and Conversion](#data-extraction-and-conversion)
 - [Data Annotation](#data-annotation)
-- [Data Augmentation](#data-augmentation)
 - [DH Centers](#dh-centers)
 - [Document Management and Processing](#document-management-and-processing)
 - [Journals](#journals)
@@ -73,10 +72,6 @@ This is a curated list of tools, resources, and services supporting the Digital 
 - [Annotation Studio](https://github.com/hyperstudio/Annotation-Studio) - Suite of tools for collaborative web-based annotation, developed by MIT's HyperStudio. 
 - [CATMA](https://catma.de/) - Computer Assisted Text Markup and Analysis.
 - [Recogito](https://recogito.pelagios.org/) - Semantic Annotation for images and texts.
-
-## Data Augmentation
-
-- [AutoCat](https://autocat.apps.allenai.org/) - Create simple text classification models online. Provided by the Allen Institute for AI (AI2).
 
 ## DH Centers
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This is a curated list of tools, resources, and services supporting the Digital 
 
 ## Data Annotation
 
-- [Annotation Studio](https://app.annotationstudio.org/) - Suite of tools for collaborative web-based annotation, developed by MIT's HyperStudio. 
+- [Annotation Studio](https://github.com/hyperstudio/Annotation-Studio) - Suite of tools for collaborative web-based annotation, developed by MIT's HyperStudio. 
 - [CATMA](https://catma.de/) - Computer Assisted Text Markup and Analysis.
 - [Recogito](https://recogito.pelagios.org/) - Semantic Annotation for images and texts.
 

--- a/README.md
+++ b/README.md
@@ -152,8 +152,6 @@ This is a curated list of tools, resources, and services supporting the Digital 
 
 ## Twitter
 
-- [CH-Centren by @Mareike2405](https://twitter.com/i/lists/732799503221284864) - List of DH centers by Mareike König.
-- [DH-People by @Mareike2405](https://twitter.com/i/lists/900392225842049024) - List of DH people by Mareike König.
 - [Digital History by @moritzmaehr](https://twitter.com/moritzmaehr/lists/digital-history) - List of Digital History people by Moritz Mährg.
 - [Digital Humanities by @GrandjeanMartin](https://twitter.com/GrandjeanMartin/lists/digital-humanities) - List of Digital Humanities people by Martin Grandjean.
 - [Digital Humanities by @normanlippert](https://twitter.com/normanlippert/lists/digital-humanities) - List of Digital Humanities people by Norman Lippert.


### PR DESCRIPTION
Remove dead links from the "Twitter" section.

**Short pitch**

- Mareike König moved her account from Twitter/X to Mastodon https://mastodon.social/@Mareike2405@fedihum.org I could not find the lists that she used to maintain and removed the dead links from the list.
- Link to Annoation Studio updated to https://github.com/hyperstudio/Annotation-Studio
- Link to AutoCat removed, tool is no longer maintained
- [ ] https://dhcenter-unil-epfl.com/ **server name not resolvable**
- [ ] https://dirtdirectory.org/ **server name not resolvable**
- [ ] http://tadirah.dariah.eu/vocab/ **server name not resolvable**
- [ ] https://digital.hssonline.org/ **server name not resolvable**
- [ ] https://vistorian.online/ **server name not resolvable**
- [ ] https://readcoop.eu/transkribus/?sc=Transkribus **403**
- [ ] https://www2.unil.ch/ladhul/fr/home.html **404**
- [ ] https://mith.umd.edu/chain/ **404**
- [ ] http://dh101.humanities.ucla.edu/ **timeout**

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/writing-resources/awesome-scientific-writing/blob/main/CONTRIBUTING.md).
- [x] Table of contents has been updated (if a section is added / removed).
- [x] Contents have been sorted alphabetically.

<!-- NOTE: Please do not skip the template -->
