### PR TITLE
Add PDF 2 EPUB to Data Extraction and Conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ This is a curated list of tools, resources, and services supporting the Digital 
 - [ImageMagick](https://imagemagick.org/) - Image conversion tool.
 - [MuPDF](https://mupdf.com/) - PDF viewer and converter.
 - [OCRmyPDF](https://github.com/jbarlow83/OCRmyPDF) - OCR toolkit.
+- [PDF 2 EPUB](https://toolkit.bot/pdf2epub) - Converts PDFs to reflowable EPUB3 with WCAG 2.2 AA accessibility compliance and OCR support.
 - [Poppler](https://poppler.freedesktop.org/) - PDF toolkit.
 - [QPDF](http://qpdf.sourceforge.net/) - PDF toolkit.
 


### PR DESCRIPTION
Adds [PDF 2 EPUB](https://toolkit.bot/pdf2epub) to the Data Extraction and Conversion section.

**What it does:** Converts PDFs to reflowable EPUB3 files with WCAG 2.2 AA accessibility compliance, OCR support for scanned documents, and two-column academic paper reflow. Free tier, no account required.

**Why it fits:** DH scholars frequently need to convert research PDFs, historical documents, and scanned sources to more accessible, machine-readable formats. PDF 2 EPUB sits naturally beside OCRmyPDF and Poppler — it adds a dedicated PDF→EPUB3 path with accessibility output.