### PR TITLE
Add ScribeTools to Data Extraction and Conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ This is a curated list of tools, resources, and services supporting the Digital 
 - [OCRmyPDF](https://github.com/jbarlow83/OCRmyPDF) - OCR toolkit.
 - [Poppler](https://poppler.freedesktop.org/) - PDF toolkit.
 - [QPDF](http://qpdf.sourceforge.net/) - PDF toolkit.
+- [ScribeTools](https://scribetools.com/) - Arabic-first document conversion for difficult non-Latin scans, with editable DOCX, searchable PDF, spreadsheet, translation, and EPUB outputs.
 
 ## Data Annotation
 


### PR DESCRIPTION
## What changed

Adds ScribeTools as one entry in **Data Extraction and Conversion**, after QPDF
to preserve alphabetical ordering.

## Short pitch

ScribeTools is a document-conversion tool for humanities researchers working
with difficult Arabic, Urdu, and other non-Latin scans. It exports editable
DOCX, searchable PDF, spreadsheet, translation, and EPUB outputs.

ScribeTools is proprietary and has a free tier. I am its founder.

## Checks

- Confirmed ScribeTools is not already listed
- Confirmed it is not in the linked rejected-resources wiki
- Confirmed there is no existing ScribeTools issue or pull request
- Ran `npx awesome-lint`
- Confirmed the linked homepage returns HTTP 200
