### PR TITLE
Add Kahve Tabela to Data Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This is a curated list of tools, resources, and services supporting the Digital 
 ## Data Collection
 
 - [Data Commons](https://datacommons.org/) - Aggregates data from a [wide range of sources](https://docs.datacommons.org/datasets/) into a unified database to make it more accessible and useful.
+- [Kahve Tabela](https://kahvetabela.com/en/acik-veri) - Open atlas of Türkiye's cultural heritage: 32,000+ registered places with WGS84 coordinates and audited Wikidata IDs, plus 4,100 regional foods of which 1,679 carry a geographical-indication registration number verifiable against the public TürkPatent registry. Versioned CSV/JSON dumps with a sha256 manifest, a free JSON API, an MCP server, and a Zenodo DOI.
 - [OpenArchive](https://open-archive.org/) - Making it easy to store, share, and amplify your mobile media while protecting your identity.
 - [Open EU Data Portal](https://data.europa.eu/euodp/en/data/) - European Union open data.
 - [Social Feed Manager](https://gwu-libraries.github.io/sfm-ui/) - Open source software that harvests social media data and web resources from Twitter, Tumblr, Flickr, and Sina Weibo.


### PR DESCRIPTION
**Pitch:** an open, citable dataset of Türkiye's cultural heritage that a DH project can download or query directly, rather than scrape.

- **32,000+ registered heritage places** — name, category, province, district, WGS84 coordinates, and entity-audited Wikidata IDs
- **4,100 regional foods**, of which **1,679 carry a geographical-indication registration number** that can be checked against the public TürkPatent registry, so a claim in a paper is verifiable rather than asserted
- **versioned CSV/JSON dumps** with a sha256 integrity manifest, so a citation can pin the exact snapshot used
- a free JSON API with an OpenAPI spec, an MCP server for LLM tooling, and a Zenodo DOI (`10.5281/zenodo.21532565`)
- licensing is layered and documented per source: CC BY for the Kültür Envanteri-derived records, ODbL for the location database via OpenStreetMap, CC0 for Wikidata-derived fields

It is already listed in [awesomedata/apd-core](https://github.com/awesomedata/apd-core/blob/master/core/Museums/Turkiye-Cultural-Heritage-Atlas-Kahve-Tabela.yml) under Museums.

Placed in **Data Collection**, alphabetically between Data Commons and OpenArchive. One entry, one line. `awesome-lint` passes locally.
