### PR TITLE
Add ArchAgent to Data Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This is a curated list of tools, resources, and services supporting the Digital 
 ## Data Analysis
 
 - [Allmaps](https://allmaps.org/) - Curating, georeferencing and exploring for IIIF maps.
+- [ArchAgent](https://github.com/Zensoro/archagent) - Open-source LLM pipeline that analyzes Chinese Neolithic-Bronze Age excavation papers, extracts chronological / attribution / typological / methodological conflicts, and aggregates them into a knowledge-graph layer with cross-paper conflict scanning.
 - [Breve](http://hdlab.stanford.edu/breve/) - Visualize and edit tabular data.
 - [Data Pen](http://hdlab.stanford.edu/data-pen/) - Framework for humanities researchers to access, explore, and manipulate multidimensional historical data.
 - [DocFetcher](http://docfetcher.sourceforge.net/) - Open Source desktop search application.


### PR DESCRIPTION
Adds ArchAgent to the Data Analysis section.

**Pitch**: ArchAgent is an open-source, MIT-licensed pipeline that runs a two-phase LLM analysis on Chinese Neolithic-Bronze Age excavation reports, extracting chronological / attribution / typological / methodological conflicts and aggregating them into a normalized knowledge-graph layer with automatic cross-paper conflict scanning. Every claim is anchored to a verbatim quote with source location, and an offline mock mode keeps tests/CI free of API keys. Bilingual docs (English + 中文), CI-green, MIT.