### PR TITLE
Fix URL for Annotation Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ This is a curated list of tools, resources, and services supporting the Digital 
 
 ## Data Annotation
 
-- [Annotation Studio](https://www.annotationstudio.org/) - Suite of tools for collaborative web-based annotation, developed by MIT's HyperStudio.
+- [Annotation Studio](https://annotation-studio.org/) - Suite of tools for collaborative web-based annotation, developed by MIT's HyperStudio.
 - [CATMA](https://catma.de/) - Computer Assisted Text Markup and Analysis.
 - [Glycerine](https://glycerine.io/) - Provides a suite of IIIF image annotation tools and end-to-end workflows for researchers, curators and students to collaborate on projects across repositories and publish research ouputs.
 - [Recogito](https://recogito.pelagios.org/) - Semantic Annotation for images and texts.


### PR DESCRIPTION
 Edit Annotation Studio link in the "Data Annotation" section.

**Short pitch**
Changed the link for Annotation Studio from https://www.annotationstudio.org/ (which goes to an empty WP shell) to https://annotation-studio.org/ (where the project seems to currently be located).

## Checklist

- [X] I have read and understood the [contribution guidelines](https://github.com/writing-resources/awesome-scientific-writing/blob/main/CONTRIBUTING.md).
- [X ] Contents have been sorted alphabetically (No changes to list order have been made).

<!-- NOTE: Please do not skip the template -->
