### PR TITLE
Add odu-core to the "Corpus linguistics" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This is a curated list of tools, resources, and services supporting the Digital 
 
 - [AntConc](https://www.laurenceanthony.net/software/antconc/) - A freeware corpus analysis toolkit for concordancing and text analysis.
 - [CorpusExplorer v2.0](http://www.CorpusExplorer.de) - Software for corpus linguists and text/data mining enthusiasts. The CorpusExplorer combines over 45 interactive visualizations under an user-friendly interface. Routine tasks such as text acquisition, cleaning or tagging are completely automated. The simple interface supports the use in university teaching and leads the users/students to fast and substantial results. The CorpusExplorer is open for many standards (XML, CSV, JSON, R, etc.) and also offers its own software development kit (SDK), which allows you to integrate all functions into your own programs.
+- [odu-core](https://github.com/timeyinallout-cloud/odu-core) - A verified dataset and Python/TypeScript library for the 256 Odù Ifá of the Yorùbá divination corpus, preserving tonal marks and subdots, with every principal figure attributed to a cited source.
 - [TXM](https://txm.gitpages.huma-num.fr/textometrie/en/) - The project brings together open-source Textometry software developments to set up a modular platform called TXM, in synergy with existing corpus technologies (Unicode, XML, TEI, NLP tools, CQP, R).
 
 ## Data Collection


### PR DESCRIPTION
Add odu-core to the "Corpus linguistics" section.

**Short pitch**

A source-attributed dataset of the Yorùbá Ifá corpus with the orthography kept
intact, usable directly from Python or TypeScript.

The 256 Odù are mapped onto the 256 values of a byte — a bijection that needs no
padding — so the corpus can be indexed, encoded, and round-tripped losslessly.
Tonal marks and subdots are preserved rather than transliterated; `to_ascii()`
exists but is documented as lossy.

Provenance is enforced rather than encouraged: every content row requires a
source, and CI fails if any of the 16 principal figures stops verifying against
its citation. MIT licensed, archived with a DOI (10.5281/zenodo.21743991), and
published on both PyPI and npm.

There isn't an obvious Datasets section in this list — Corpus linguistics looked
like the closest fit, but happy to move it if you'd rather it sat elsewhere.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/dh-tech/awesome-digital-humanities/blob/main/CONTRIBUTING.md).
- [x] Table of contents has been updated (if a section is added / removed).
- [x] Contents have been sorted alphabetically.
