### PR TITLE
Add PDFAnnotations to Data Extraction and Conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ This is a curated list of tools, resources, and services supporting the Digital 
 - [OCRmyPDF](https://github.com/jbarlow83/OCRmyPDF) - OCR toolkit.
 - [Poppler](https://poppler.freedesktop.org/) - PDF toolkit.
 - [QPDF](http://qpdf.sourceforge.net/) - PDF toolkit.
+- [PDFAnnotations](https://pdfannotations.com/) - Extract PDF highlights, comments, and notes into Markdown, CSV, plain text, or JSON — directly in your browser.
+
+
 
 ## Data Annotation
 


### PR DESCRIPTION
Add PDFAnnotations to the "Data Extraction and Conversion" section.

**Short pitch**

PDFAnnotations makes it easy to reuse information already captured in annotated PDFs. It extracts highlights, comments, and notes and converts them into Markdown, CSV, plain text, or JSON.

I find it useful when reading and annotating research papers in a regular PDF reader, then needing to move those annotations into a writing or note-taking workflow. Unlike PDF annotation editors, PDFAnnotations focuses on extracting and reusing annotations that already exist in a PDF.

## Checklist

* [x] I have read and understood the [[contribution guidelines](https://github.com/writing-resources/awesome-scientific-writing/blob/main/CONTRIBUTING.md)](https://github.com/writing-resources/awesome-scientific-writing/blob/main/CONTRIBUTING.md).
* [x] Contents have been sorted alphabetically.