### PR TITLE
Add Introduction to Digital Humanities (Bern)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ This is a curated list of tools, resources, and services supporting the Digital 
 - [Framework for Information Literacy for Higher Education](http://www.ala.org/acrl/standards/ilframework) - How to teach digital literacy.
 - [Humanities Data Analysis](https://www.humanitiesdataanalysis.org/) - A practical guide to data-intensive humanities research using the Python programming language.
 - [Intro Cultural Analytics](https://melaniewalsh.github.io/Intro-Cultural-Analytics/welcome.html) - Analyze cultural artifacts with Python.
+- [Introduction to Digital Humanities (Bern)](https://dhbern.github.io/introduction-to-dh/contents/home.html) - Open course materials of the [University of Bern](https://www.unibe.ch/) that cover data modeling, Linked Open Data, data publication, text, network and geospatial analysis, machine learning, and sustainability. No prior programming knowledge is required.
 - [Introduction to Digital Humanities (DH101)](https://asandersgarcia.humspace.ucla.edu/courses/dh101f18/) - Collection of resources/online coursebook based on the _Introduction to Digital Humanities (DH101)_ course at [UCLA](http://www.ucla.edu/).
 - [Jupyter Notebooks for Digital Humanities](https://github.com/quinnanya/dh-jupyter/blob/master/README.md) - A diverse range of Jupyter notebooks, comprising research materials, course content, Python tutorials, and specific analysis tools.
 - [Missing Semester](https://missing.csail.mit.edu/) - Useful tools that are not taught in class.


### PR DESCRIPTION
Add [Introduction to Digital Humanities (Bern)](https://dhbern.github.io/introduction-to-dh/contents/home.html) to the "User Guides and Training Materials" section.

**Short pitch**

These are the open course materials of the Digital Humanities chair at the University of Bern (Walter Benjamin Kolleg). They are published under CC BY-SA 4.0 and cover a complete research workflow: definitions of DH, data concepts, data modeling, Linked Open Data, data publication, text, network and geospatial analysis, machine learning and large language models, and sustainability.

The list already contains the UCLA course DH101. This entry adds a second, more recent syllabus with a stronger focus on Linked Open Data and machine learning. It needs no prior programming knowledge, so it fits readers who start with DH. I use it as a reading list when I teach and when I point students to a structured entry point.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/dh-tech/awesome-digital-humanities/blob/main/CONTRIBUTING.md).
- [x] Table of contents has been updated (if a section is added / removed).
- [x] Contents have been sorted alphabetically.

`npx awesome-lint README.md` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXytSHUc55j5KguwGfqf42