### PR TITLE
chore: update GitHub Actions to current major versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "docs"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,15 +1,18 @@
 awesome:
-- README.md
+  - changed-files:
+      - any-glob-to-any-file: 'README.md'
 
 docs:
-- .github/*
-- _layouts/*
-- assets/*
-- _config.yml
-- 404.md
-- CODE_OF_CONDUCT.md
-- CONTRIBUTING.md
-- LICENSE.md
-- SECURITY.md
-- .gitattributes
-- .gitignore
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+          - '_layouts/**'
+          - 'assets/**'
+          - '_config.yml'
+          - '404.md'
+          - 'CODE_OF_CONDUCT.md'
+          - 'CONTRIBUTING.md'
+          - 'LICENSE'
+          - 'SECURITY.md'
+          - '.gitattributes'
+          - '.gitignore'

--- a/.github/workflows/awesome-lint.yml
+++ b/.github/workflows/awesome-lint.yml
@@ -12,4 +12,5 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - run: npx awesome-lint

--- a/.github/workflows/awesome-lint.yml
+++ b/.github/workflows/awesome-lint.yml
@@ -2,11 +2,14 @@ name: awesome-lint
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   Awesome_Lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - run: npx awesome-lint

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -2,12 +2,16 @@ name: Greetings
 
 on: [pull_request, issues]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   greeting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/first-interaction@v1
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        issue-message: 'Hi there! Thanks for opening your first issue!'
-        pr-message: 'Hi there! Thanks for opening your first pull request!'
+      - uses: actions/first-interaction@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: 'Hi there! Thanks for opening your first issue!'
+          pr-message: 'Hi there! Thanks for opening your first pull request!'

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,11 +1,16 @@
 name: "Pull Request Labeler"
+
 on:
-- pull_request_target
+  - pull_request_target
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v3
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: actions/labeler@v7
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,20 +2,22 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: "0 0 * * *"
+    - cron: "0 0 * * *"
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   stale:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/stale@v1
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Stale issue message'
-        stale-pr-message: 'Stale pull request message'
-        stale-issue-label: 'no-issue-activity'
-        stale-pr-label: 'no-pr-activity'
-        days-before-stale: 60
-        days-before-close: 5
+      - uses: actions/stale@v11
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'Stale issue message'
+          stale-pr-message: 'Stale pull request message'
+          stale-issue-label: 'no-issue-activity'
+          stale-pr-label: 'no-pr-activity'
+          days-before-stale: 60
+          days-before-close: 5


### PR DESCRIPTION
Maintenance and hardening. No entry is added, removed, or edited.

**Short pitch**

All four workflows pin action versions that GitHub deprecates. `actions/checkout@v2` and `actions/stale@v1` run on Node 16 and already print deprecation warnings on `ubuntu-latest`. This PR moves them to the current major versions and closes two small security gaps in the same files.

## 1. Action versions

| Workflow | Before | After |
| --- | --- | --- |
| `awesome-lint.yml` | `actions/checkout@v2` | `actions/checkout@v7` |
| `label.yml` | `actions/labeler@v3` | `actions/labeler@v7` |
| `stale.yml` | `actions/stale@v1` | `actions/stale@v11` |
| `greetings.yml` | `actions/first-interaction@v1` | `actions/first-interaction@v3` |

## 2. Configuration that the bump requires

1. `actions/labeler` v5 replaced the configuration schema. `.github/labeler.yml` now uses the `changed-files` / `any-glob-to-any-file` form. Without this change the labeler fails on every pull request.
2. The glob `.github/*` becomes `.github/**`. A single asterisk does not match a path that contains a directory, so the old glob never matched `.github/workflows/*.yml`. The entry `LICENSE.md` becomes `LICENSE`, the real file name.
3. Each workflow gets an explicit `permissions` block. The newer actions need write access to issues or pull requests, and the default token is read-only in many organisations.

## 3. Hardening

1. `awesome-lint.yml` sets `persist-credentials: false` on the checkout step. That step writes the job token into `.git/config`. The next step runs `npx awesome-lint`, which downloads and runs third-party code from npm in the same job. The flag removes the token before that code runs. The job only reads the repository, so it does not need the credential.
2. New `.github/dependabot.yml` for the `github-actions` ecosystem, grouped and monthly. Dependabot then reports the next version bump, so these files do not fall four major versions behind again.

## Note on verification

`label.yml` runs on `pull_request_target`. That event always uses the workflow and the configuration from the base branch, so this pull request runs the **old** labeler with the **old** config. The new pair cannot be exercised until it is on `main`. The [labeler README documents this](https://github.com/actions/labeler#notes-regarding-pull_request_target-event). Both files change together, so the state after merge is consistent.

## Known limitation, not changed here

`greetings.yml` runs on `pull_request`. GitHub gives a read-only token to that event for pull requests from forks, so the greeting comment never posts on an external contribution. The fix is `pull_request_target`. That is a trigger change with security implications, so I left it out. Tell me if you want it and I will open a separate pull request.

## Verification

- Every workflow file, `labeler.yml`, and `dependabot.yml` parses as valid YAML.
- Action versions come from each repository's latest release tag.
- No workflow interpolates `github.event` data into a `run` block, so there is no script injection path.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/dh-tech/awesome-digital-humanities/blob/main/CONTRIBUTING.md).
- [x] Table of contents has been updated (if a section is added / removed). — not applicable
- [x] Contents have been sorted alphabetically. — not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXytSHUc55j5KguwGfqf42